### PR TITLE
Fix issue with Dice without d not working on >2 digits

### DIFF
--- a/spec/Kachuru/Util/DiceSpec.php
+++ b/spec/Kachuru/Util/DiceSpec.php
@@ -12,49 +12,55 @@ class DiceSpec extends ObjectBehavior
     function it_rolls_six_sides_by_default()
     {
         for ($i = 0; $i < self::ROLL_ATTEMPTS; $i++) {
-            $this->roll()->shouldBeAnyOf([1, 2, 3, 4, 5, 6]);
+            $this->roll()->shouldBeAnyOf(range(1, 6));
         }
     }
 
     function it_rolls_a_d4()
     {
         for ($i = 0; $i < self::ROLL_ATTEMPTS; $i++) {
-            $this->roll('d4')->shouldBeAnyOf([1, 2, 3, 4]);
+            $this->roll('d4')->shouldBeAnyOf(range(1, 4));
         }
     }
 
     function it_rolls_2d6()
     {
         for ($i = 0; $i < self::ROLL_ATTEMPTS; $i++) {
-            $this->roll('2d6')->shouldBeAnyOf([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+            $this->roll('2d6')->shouldBeAnyOf(range(2, 12));
         }
     }
 
     function it_roles_3d5()
     {
         for ($i = 0; $i < self::ROLL_ATTEMPTS; $i++) {
-            $this->roll('3d5')->shouldBeAnyOf([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+            $this->roll('3d5')->shouldBeAnyOf(range(3, 15));
         }
     }
 
     function it_applies_a_modifier_d4minus1()
     {
         for ($i = 0; $i < self::ROLL_ATTEMPTS; $i++) {
-            $this->roll('2d4-1')->shouldBeAnyOf([0, 1, 2, 3, 4, 5, 6, 7]);
+            $this->roll('2d4-1')->shouldBeAnyOf(range(0, 7));
         }
     }
 
     function it_applies_a_modifier_26plus2()
     {
         for ($i = 0; $i < self::ROLL_ATTEMPTS; $i++) {
-            $this->roll('d6+2')->shouldBeAnyOf([3, 4, 5, 6, 7, 8]);
+            $this->roll('d6+2')->shouldBeAnyOf(range(3, 8));
         }
     }
 
-    function it_does_not_need_the_d()
+    function it_rolls_a_twelve()
     {
-        $this->roll('6')->shouldBeAnyOf([1, 2, 3, 4, 5, 6]);
+        $this->roll('12')->shouldbeAnyOf(range(1, 12));
     }
+
+    function it_rolls_a_hundred()
+    {
+        $this->roll('100')->shouldBeAnyOf(range(1, 100));
+    }
+
 
     public function getMatchers(): array
     {

--- a/src/Kachuru/Util/Dice.php
+++ b/src/Kachuru/Util/Dice.php
@@ -8,18 +8,21 @@ use Kachuru\Util\Exception\InvalidDiceDefinitionException;
 
 class Dice
 {
-    private const DICE_DEFINITION_PATTERN = '^(?P<times>[0-9]*)d?(?P<sides>[0-9]+)(?P<modifier>(\+|\-)[0-9]*)?$';
+    private const DICE_DEFINITION_PATTERN = '^(?P<times>[0-9]+)?d?(?P<sides>[0-9]+)(?P<modifier>(\+|\-)[0-9]*)?$';
 
     public function roll(string $definition = 'd6'): int
     {
+        if (is_numeric($definition)) {
+            $definition = 'd' . $definition;
+        }
+
         if (!preg_match(sprintf('/%s/i', self::DICE_DEFINITION_PATTERN), $definition, $result)) {
             throw new InvalidDiceDefinitionException(sprintf('The definition "%s" could not be parsed', $definition));
         }
 
-        $times = (int) $result['times'];
-        if (empty($times)) {
-            $times = 1;
-        }
+        $times = !empty($result['times'])
+            ? intval($result['times'])
+            : 1;
 
         return $this->doRoll((int) $result['sides'], $times)
             + ((array_key_exists('modifier', $result)) ? (int) $result['modifier'] : 0);


### PR DESCRIPTION
a definition without a 'd' in it would not work. This fixes it to add the 'd' if it's not present.